### PR TITLE
fixing groupId for artifact publishing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.homeaway.dropwizard.bundle</groupId>
+    <groupId>com.expediagroup.dropwizard.bundle</groupId>
     <artifactId>dropwizard-resilience4j-bundle</artifactId>
     <version>0.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>


### PR DESCRIPTION
# resilience4j dropwizard bundle PR

### Changed
* switched artifact groupId from homeaway to expediagroup
