### PR TITLE
[MAJOR] Update to R4j 1.1.0, and implement Retries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ overlays
 *.iml
 *.iws
 .idea
+*.versionsBackup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
 ### Changed
-- nothing yet
+- Added support for R4j `Retry`
+- Updated to R4j 1.1.0. This is a major version bump that has a lot of breaking changes that will be user-visible. See R4j documentation for details.
 
 
 ##[0.0.1] - 2019-03-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
-### Changed
+### Added
 - Added support for R4j `Retry`
-- Updated to R4j 1.1.0. This is a major version bump that has a lot of breaking changes that will be user-visible. See R4j documentation for details.
 
+### Changed
+- Updated to R4j 1.1.0. This is a major version bump that has a lot of breaking changes that will be user-visible. See R4j documentation for details.
 
 ##[0.0.1] - 2019-03-11
 ###Initial Version

--- a/README.md
+++ b/README.md
@@ -6,10 +6,9 @@ dropwizard-resilience4j-bundle [![Build Status][build-icon]][build-link]
 
 
 Lightweight integration of Resilience4J into Dropwizard configuration and metrics. Does not provide any other services - actually _using_
-all the Resilience4j stuff is up to you.
+all the Resilience4j stuff is up to you. The [R4J documentation](https://resilience4j.readme.io/docs) is pretty good.
 
-Currently this only supports Circuit Breakers, but supporting [more R4j features is welcome](http://resilience4j.github.io/resilience4j/#_usage_guide).
-
+Currently this only supports Circuit Breakers and Retries, but supporting [more R4j features is welcome](http://resilience4j.github.io/resilience4j/#_usage_guide).
 
 User Guide
 ==============================
@@ -29,10 +28,21 @@ resilience4j:
     circuitBreakers:
         - name: myFancyCircuitBreaker
           waitDurationInOpenState: 30s
-          ringBufferSizeInClosedState: 30
+          failureRateThreshold: 10
         ## Add as many as you want
         ## All parameters are optional except `name`, defaults are documented in CircuitBreakerConfiguration.java
         ##- name: anotherCircuitBreaker
+    retryConfigurations:
+      - name: exponentialRandomizedBackoffRetry
+              maxAttempts: 4
+              intervalFunction:
+                type: exponentialRandomBackoff
+                initialInterval: 10ms
+                multiplier: 2.5
+                randomizationFactor: 0.5
+      ## Add as many as you want
+      ## most parameters are optional, but `intervalFunction` is required. Several are available, see `IntervalFunctionFactory` for full list, 
+      ## but currently: constant, randomized, exponentialBackoff, exponentialRandomBackoff
 ```
 
 Add to your application's Config class:
@@ -41,21 +51,28 @@ Add to your application's Config class:
 private Resilience4jConfiguration resilience4j;
 ```
 
-The circuit breakers are automatically wired into Dropwizard Metrics, and also [into HK2 using the name from the YAML](src/main/java/com/homeaway/dropwizard/bundle/resilience4j/Resilience4jBundle.java#L93).
+Configured R4J objects are automatically wired into Dropwizard Metrics, and also [into HK2 using the name from the YAML](src/main/java/com/homeaway/dropwizard/bundle/resilience4j/Resilience4jBundle.java#L93).
 You can also retrieve them from the configuration class...
 
 ```java
 val breaker = myAppConfig.getResilience4j().getCircuitBreakerRegistry().circuitBreaker("myFancyCircuitBreaker");
+val retry = myAppConfig.getResilience4j().getRetryRegistry().retry("myFancyRetry");
 ```
 
-If you want to configure the CircuitBreakers in code before they are created, you can pass a handler into the bundle when it's constructed.
+If you want to configure the objects in code before they are created, you can pass a handler into the bundle when it's constructed.
 ```java
 @Override
 public void initialize(Bootstrap<RatesEngineConfiguration> bootstrap) {
-    bootstrap.addBundle(new Resilience4jBundle<>(RatesEngineConfiguration::getResilience4j, (breakerName, breakerBuilder) -> {
-                //breakerName is what was configured in YAML
-                //breakerBuilder can be modified as desired
-                breakerBuilder.ignoreExceptions(IOException.class);
-            }));
+    bootstrap.addBundle(new Resilience4jBundle<>(TestConfiguration::getResilience4j,
+                                                 (breakerName, breakerBuilder) -> {
+                                                     //breakerName is what was configured in YAML
+                                                     //breakerBuilder can be modified as desired
+                                                     breakerBuilder.ignoreExceptions(IOException.class);
+                                                 },
+                                                 (retryName, retryBuilder) -> {
+                                                     //retryName is what was configured in YAML
+                                                     //retryBuilder can be modified as desired
+                                                     retryBuilder.retryOnResult(myRetryPredicate);
+                                                 }));
 }
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -45,9 +45,10 @@
         <hk2-api.version>2.5.0-b32</hk2-api.version>
         <junit.version>4.12</junit.version>
         <rs-api.version>2.0.1</rs-api.version>
-        <resilience4j.version>0.13.1</resilience4j.version>
+        <resilience4j.version>1.1.0</resilience4j.version>
+        <slf4j.version>1.7.25</slf4j.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
-        <vavr.version>0.9.2</vavr.version>
+        <vavr.version>0.10.0</vavr.version>
 
     </properties>
 
@@ -65,12 +66,20 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
@@ -95,6 +104,11 @@
             <version>${resilience4j.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-retry</artifactId>
+            <version>${resilience4j.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.vavr</groupId>
             <artifactId>vavr</artifactId>
             <version>${vavr.version}</version>
@@ -108,6 +122,10 @@
             <groupId>org.glassfish.hk2</groupId>
             <artifactId>hk2-api</artifactId>
             <version>${hk2-api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-validator</artifactId>
         </dependency>
 
         <!-- Test scoped dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.expediagroup.dropwizard.bundle</groupId>
     <artifactId>dropwizard-resilience4j-bundle</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>dropwizard-resilience4j-bundle</name>

--- a/src/main/java/com/homeaway/dropwizard/bundle/resilience4j/configuration/CircuitBreakerConfiguration.java
+++ b/src/main/java/com/homeaway/dropwizard/bundle/resilience4j/configuration/CircuitBreakerConfiguration.java
@@ -16,6 +16,8 @@ limitations under the License.
 
 package com.homeaway.dropwizard.bundle.resilience4j.configuration;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import io.dropwizard.util.Duration;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 
@@ -27,6 +29,7 @@ public class CircuitBreakerConfiguration {
     /**
      * Name for this circuit breaker for use in the registry
      */
+    @JsonProperty
     private String name;
 
     /**
@@ -35,28 +38,8 @@ public class CircuitBreakerConfiguration {
      * <br>
      * See also {@link io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.Builder#failureRateThreshold}.
      */
+    @JsonProperty
     private float failureRateThreshold = 50;
-
-    /**
-     * Configures the size of the ring buffer when the CircuitBreaker is half open. The CircuitBreaker stores the success/failure
-     * success / failure status of the latest calls in a ring buffer. For example, if {@code ringBufferSizeInClosedState} is 10, then
-     * at least 10 calls must be evaluated, before the failure rate can be calculated. If only 9 calls have been evaluated the
-     * CircuitBreaker will not trip back to closed or open even if all 9 calls have failed. The size must be greater than 10. Default
-     * size is 10.
-     * <br>
-     * See also {@link io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.Builder#ringBufferSizeInHalfOpenState}.
-     */
-    private int ringBufferSizeInHalfOpenState = 10;
-
-    /**
-     * Configures the size of the ring buffer when the CircuitBreaker is closed. The CircuitBreaker stores the success/failure
-     * success / failure status of the latest calls in a ring buffer. For example, if {@code ringBufferSizeInClosedState} is 100,
-     * then at least 100 calls must be evaluated, before the failure rate can be calculated. If only 99 calls have been evaluated the
-     * CircuitBreaker will not trip open even if all 99 calls have failed. The size must be greater than 0. Default size is 100.
-     * <br>
-     * See also {@link io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.Builder#ringBufferSizeInClosedState}.
-     */
-    private int ringBufferSizeInClosedState = 100;
 
     /**
      * Configures the wait duration which specifies how long the CircuitBreaker should stay open, before it switches to half open.
@@ -64,6 +47,7 @@ public class CircuitBreakerConfiguration {
      * <br>
      * See also {@link io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.Builder#waitDurationInOpenState}.
      */
+    @JsonProperty
     private Duration waitDurationInOpenState = Duration.seconds(60);
 
     /**
@@ -71,20 +55,50 @@ public class CircuitBreakerConfiguration {
      * Default value is {c}true{/c}
      * See also {@link io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.Builder#enableAutomaticTransitionFromOpenToHalfOpen}.
      */
+    @JsonProperty
     private Boolean enableAutomaticTransitionFromOpenToHalfOpen = true;
 
+    @JsonProperty
+    private int minimumNumberOfCalls = CircuitBreakerConfig.DEFAULT_MINIMUM_NUMBER_OF_CALLS;
+
+    @JsonProperty
+    private int permittedNumberOfCallsInHalfOpenState = CircuitBreakerConfig.DEFAULT_PERMITTED_CALLS_IN_HALF_OPEN_STATE;
+
+    @JsonProperty
+    private int slidingWindowSize = CircuitBreakerConfig.DEFAULT_SLIDING_WINDOW_SIZE;
+
+    @JsonProperty
+    private CircuitBreakerConfig.SlidingWindowType slidingWindowType = CircuitBreakerConfig.DEFAULT_SLIDING_WINDOW_TYPE;
+
+    @JsonProperty
+    private Duration slowCallDurationThreshold = Duration.seconds(CircuitBreakerConfig.DEFAULT_SLOW_CALL_DURATION_THRESHOLD);
+
+    @JsonProperty
+    private float slowCallRateThreshold = CircuitBreakerConfig.DEFAULT_SLOW_CALL_RATE_THRESHOLD;
+
+    @JsonProperty
+    private boolean writableStackTraceEnabled = CircuitBreakerConfig.DEFAULT_WRITABLE_STACK_TRACE_ENABLED;
+
+    @JsonProperty
+    private Class[] ignoreExceptions = new Class[0];
+
+    @JsonProperty
+    private Class[] recordExceptions = new Class[0];
+
     public CircuitBreakerConfig.Builder toResilience4jConfigBuilder() {
-        CircuitBreakerConfig.Builder builder = CircuitBreakerConfig.custom()
-                                          .waitDurationInOpenState(java.time.Duration.ofNanos(this.waitDurationInOpenState.toNanoseconds()))
-                                          .ringBufferSizeInClosedState(this.ringBufferSizeInClosedState)
-                                          .ringBufferSizeInHalfOpenState(this.ringBufferSizeInHalfOpenState)
-                                          .failureRateThreshold(this.failureRateThreshold);
-
-        if (enableAutomaticTransitionFromOpenToHalfOpen) {
-            builder.enableAutomaticTransitionFromOpenToHalfOpen();
-        }
-
-        return builder;
+        return CircuitBreakerConfig.custom()
+                                   .waitDurationInOpenState(java.time.Duration.ofNanos(this.waitDurationInOpenState.toNanoseconds()))
+                                   .automaticTransitionFromOpenToHalfOpenEnabled(enableAutomaticTransitionFromOpenToHalfOpen)
+                                   .failureRateThreshold(this.failureRateThreshold)
+                                   .minimumNumberOfCalls(minimumNumberOfCalls)
+                                   .permittedNumberOfCallsInHalfOpenState(permittedNumberOfCallsInHalfOpenState)
+                                   .slidingWindowSize(slidingWindowSize)
+                                   .slidingWindowType(slidingWindowType)
+                                   .slowCallDurationThreshold(java.time.Duration.ofNanos(slowCallDurationThreshold.toNanoseconds()))
+                                   .slowCallRateThreshold(slowCallRateThreshold)
+                                   .writableStackTraceEnabled(writableStackTraceEnabled)
+                                   .ignoreExceptions(ignoreExceptions)
+                                   .recordExceptions(recordExceptions);
     }
 
     public String getName() {
@@ -103,22 +117,6 @@ public class CircuitBreakerConfiguration {
         return failureRateThreshold;
     }
 
-    public void setRingBufferSizeInHalfOpenState(int ringBufferSizeInHalfOpenState) {
-        this.ringBufferSizeInHalfOpenState = ringBufferSizeInHalfOpenState;
-    }
-
-    public int getRingBufferSizeInHalfOpenState() {
-        return ringBufferSizeInHalfOpenState;
-    }
-
-    public int getRingBufferSizeInClosedState() {
-        return ringBufferSizeInClosedState;
-    }
-
-    public void setRingBufferSizeInClosedState(int ringBufferSizeInClosedState) {
-        this.ringBufferSizeInClosedState = ringBufferSizeInClosedState;
-    }
-
     public Duration getWaitDurationInOpenState() {
         return waitDurationInOpenState;
     }
@@ -133,5 +131,77 @@ public class CircuitBreakerConfiguration {
 
     public void setEnableAutomaticTransitionFromOpenToHalfOpen(Boolean enableAutomaticTransitionFromOpenToHalfOpen) {
         this.enableAutomaticTransitionFromOpenToHalfOpen = enableAutomaticTransitionFromOpenToHalfOpen;
+    }
+
+    public int getMinimumNumberOfCalls() {
+        return minimumNumberOfCalls;
+    }
+
+    public void setMinimumNumberOfCalls(int minimumNumberOfCalls) {
+        this.minimumNumberOfCalls = minimumNumberOfCalls;
+    }
+
+    public int getPermittedNumberOfCallsInHalfOpenState() {
+        return permittedNumberOfCallsInHalfOpenState;
+    }
+
+    public void setPermittedNumberOfCallsInHalfOpenState(int permittedNumberOfCallsInHalfOpenState) {
+        this.permittedNumberOfCallsInHalfOpenState = permittedNumberOfCallsInHalfOpenState;
+    }
+
+    public int getSlidingWindowSize() {
+        return slidingWindowSize;
+    }
+
+    public void setSlidingWindowSize(int slidingWindowSize) {
+        this.slidingWindowSize = slidingWindowSize;
+    }
+
+    public CircuitBreakerConfig.SlidingWindowType getSlidingWindowType() {
+        return slidingWindowType;
+    }
+
+    public void setSlidingWindowType(CircuitBreakerConfig.SlidingWindowType slidingWindowType) {
+        this.slidingWindowType = slidingWindowType;
+    }
+
+    public Duration getSlowCallDurationThreshold() {
+        return slowCallDurationThreshold;
+    }
+
+    public void setSlowCallDurationThreshold(Duration slowCallDurationThreshold) {
+        this.slowCallDurationThreshold = slowCallDurationThreshold;
+    }
+
+    public float getSlowCallRateThreshold() {
+        return slowCallRateThreshold;
+    }
+
+    public void setSlowCallRateThreshold(float slowCallRateThreshold) {
+        this.slowCallRateThreshold = slowCallRateThreshold;
+    }
+
+    public boolean isWritableStackTraceEnabled() {
+        return writableStackTraceEnabled;
+    }
+
+    public void setWritableStackTraceEnabled(boolean writableStackTraceEnabled) {
+        this.writableStackTraceEnabled = writableStackTraceEnabled;
+    }
+
+    public Class[] getIgnoreExceptions() {
+        return ignoreExceptions;
+    }
+
+    public void setIgnoreExceptions(Class[] ignoreExceptions) {
+        this.ignoreExceptions = ignoreExceptions;
+    }
+
+    public Class[] getRecordExceptions() {
+        return recordExceptions;
+    }
+
+    public void setRecordExceptions(Class[] recordExceptions) {
+        this.recordExceptions = recordExceptions;
     }
 }

--- a/src/main/java/com/homeaway/dropwizard/bundle/resilience4j/configuration/CircuitBreakerConfiguration.java
+++ b/src/main/java/com/homeaway/dropwizard/bundle/resilience4j/configuration/CircuitBreakerConfiguration.java
@@ -80,10 +80,10 @@ public class CircuitBreakerConfiguration {
     private boolean writableStackTraceEnabled = CircuitBreakerConfig.DEFAULT_WRITABLE_STACK_TRACE_ENABLED;
 
     @JsonProperty
-    private Class[] ignoreExceptions = new Class[0];
+    private Class<? extends Throwable>[] ignoreExceptions = new Class[0];
 
     @JsonProperty
-    private Class[] recordExceptions = new Class[0];
+    private Class<? extends Throwable>[] recordExceptions = new Class[0];
 
     public CircuitBreakerConfig.Builder toResilience4jConfigBuilder() {
         return CircuitBreakerConfig.custom()
@@ -189,19 +189,19 @@ public class CircuitBreakerConfiguration {
         this.writableStackTraceEnabled = writableStackTraceEnabled;
     }
 
-    public Class[] getIgnoreExceptions() {
+    public Class<? extends Throwable>[] getIgnoreExceptions() {
         return ignoreExceptions;
     }
 
-    public void setIgnoreExceptions(Class[] ignoreExceptions) {
+    public void setIgnoreExceptions(Class<? extends Throwable>[] ignoreExceptions) {
         this.ignoreExceptions = ignoreExceptions;
     }
 
-    public Class[] getRecordExceptions() {
+    public Class<? extends Throwable>[] getRecordExceptions() {
         return recordExceptions;
     }
 
-    public void setRecordExceptions(Class[] recordExceptions) {
+    public void setRecordExceptions(Class<? extends Throwable>[] recordExceptions) {
         this.recordExceptions = recordExceptions;
     }
 }

--- a/src/main/java/com/homeaway/dropwizard/bundle/resilience4j/configuration/Resilience4jConfiguration.java
+++ b/src/main/java/com/homeaway/dropwizard/bundle/resilience4j/configuration/Resilience4jConfiguration.java
@@ -21,7 +21,10 @@ import java.util.List;
 import javax.annotation.Nullable;
 import javax.validation.Valid;
 
+import com.homeaway.dropwizard.bundle.resilience4j.configuration.retry.RetryConfiguration;
+
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.resilience4j.retry.RetryRegistry;
 
 /**
  * Resilience4j configuration
@@ -35,7 +38,13 @@ public class Resilience4jConfiguration {
     @Valid
     private List<CircuitBreakerConfiguration> circuitBreakers;
 
+    @Nullable
+    @Valid
+    private List<RetryConfiguration> retryConfigurations;
+
     public CircuitBreakerRegistry circuitBreakerRegistry;
+
+    public RetryRegistry retryRegistry;
 
     @Nullable
     public List<CircuitBreakerConfiguration> getCircuitBreakers() {
@@ -52,5 +61,22 @@ public class Resilience4jConfiguration {
 
     public void setCircuitBreakerRegistry(CircuitBreakerRegistry circuitBreakerRegistry) {
         this.circuitBreakerRegistry = circuitBreakerRegistry;
+    }
+
+    @Nullable
+    public List<RetryConfiguration> getRetryConfigurations() {
+        return retryConfigurations;
+    }
+
+    public void setRetryConfigurations(@Nullable List<RetryConfiguration> retryConfigurations) {
+        this.retryConfigurations = retryConfigurations;
+    }
+
+    public RetryRegistry getRetryRegistry() {
+        return retryRegistry;
+    }
+
+    public void setRetryRegistry(RetryRegistry retryRegistry) {
+        this.retryRegistry = retryRegistry;
     }
 }

--- a/src/main/java/com/homeaway/dropwizard/bundle/resilience4j/configuration/retry/ConstantIntervalFunctionFactory.java
+++ b/src/main/java/com/homeaway/dropwizard/bundle/resilience4j/configuration/retry/ConstantIntervalFunctionFactory.java
@@ -1,0 +1,30 @@
+package com.homeaway.dropwizard.bundle.resilience4j.configuration.retry;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import io.dropwizard.util.Duration;
+import io.github.resilience4j.retry.IntervalFunction;
+
+@JsonTypeName("constant")
+public class ConstantIntervalFunctionFactory implements IntervalFunctionFactory {
+
+    /**
+     * Wait interval. Minimum value is 10 milliseconds. Default is R4j default, currently 500ms.
+     */
+    @JsonProperty
+    private Duration initialInterval = Duration.milliseconds(IntervalFunction.DEFAULT_INITIAL_INTERVAL);
+
+    @Override
+    public IntervalFunction build() {
+        return IntervalFunction.of(initialInterval.toMilliseconds());
+    }
+
+    public Duration getInitialInterval() {
+        return initialInterval;
+    }
+
+    public void setInitialInterval(Duration initialInterval) {
+        this.initialInterval = initialInterval;
+    }
+}

--- a/src/main/java/com/homeaway/dropwizard/bundle/resilience4j/configuration/retry/ExponentialBackoffFunctionFactory.java
+++ b/src/main/java/com/homeaway/dropwizard/bundle/resilience4j/configuration/retry/ExponentialBackoffFunctionFactory.java
@@ -1,0 +1,48 @@
+package com.homeaway.dropwizard.bundle.resilience4j.configuration.retry;
+
+import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import io.dropwizard.util.Duration;
+import io.github.resilience4j.retry.IntervalFunction;
+
+@JsonTypeName("exponentialBackoff")
+public class ExponentialBackoffFunctionFactory implements IntervalFunctionFactory {
+
+    /**
+     * Amount to multiply by at each iteration. Must be greater than 1.  Default value is 1.5.
+     */
+    @JsonProperty
+    @NotNull
+    private double multiplier = IntervalFunction.DEFAULT_MULTIPLIER;
+
+    /**
+     * Initial interval. Minimum value is 10 milliseconds. Default is R4j default, currently 500ms.
+     */
+    @JsonProperty
+    @NotNull
+    private Duration initialInterval = Duration.milliseconds(IntervalFunction.DEFAULT_INITIAL_INTERVAL);
+
+    @Override
+    public IntervalFunction build() {
+        return IntervalFunction.ofExponentialBackoff(initialInterval.toMilliseconds(), multiplier);
+    }
+
+    public double getMultiplier() {
+        return multiplier;
+    }
+
+    public void setMultiplier(double multiplier) {
+        this.multiplier = multiplier;
+    }
+
+    public Duration getInitialInterval() {
+        return initialInterval;
+    }
+
+    public void setInitialInterval(Duration initialInterval) {
+        this.initialInterval = initialInterval;
+    }
+}

--- a/src/main/java/com/homeaway/dropwizard/bundle/resilience4j/configuration/retry/ExponentialRandomBackoffFunctionFactory.java
+++ b/src/main/java/com/homeaway/dropwizard/bundle/resilience4j/configuration/retry/ExponentialRandomBackoffFunctionFactory.java
@@ -1,0 +1,63 @@
+package com.homeaway.dropwizard.bundle.resilience4j.configuration.retry;
+
+import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import io.dropwizard.util.Duration;
+import io.github.resilience4j.retry.IntervalFunction;
+
+@JsonTypeName("exponentialRandomBackoff")
+public class ExponentialRandomBackoffFunctionFactory implements IntervalFunctionFactory {
+
+    /**
+     * Amount to multiply by at each iteration. Must be greater than 1. Default value is 1.5.
+     */
+    @JsonProperty
+    @NotNull
+    private double multiplier = IntervalFunction.DEFAULT_MULTIPLIER;
+
+    /**
+     * Randomization multiplier. Must be in range [0.0d, 1.0d). Default value is 0.5.
+     */
+    @JsonProperty
+    @NotNull
+    private double randomizationFactor = IntervalFunction.DEFAULT_RANDOMIZATION_FACTOR;
+
+    /**
+     * Initial interval. Minimum value is 10 milliseconds. Default is R4j default, currently 500ms.
+     */
+    @JsonProperty
+    @NotNull
+    private Duration initialInterval = Duration.milliseconds(IntervalFunction.DEFAULT_INITIAL_INTERVAL);
+
+    @Override
+    public IntervalFunction build() {
+        return IntervalFunction.ofExponentialRandomBackoff(initialInterval.toMilliseconds(), multiplier, randomizationFactor);
+    }
+
+    public double getMultiplier() {
+        return multiplier;
+    }
+
+    public void setMultiplier(double multiplier) {
+        this.multiplier = multiplier;
+    }
+
+    public double getRandomizationFactor() {
+        return randomizationFactor;
+    }
+
+    public void setRandomizationFactor(double randomizationFactor) {
+        this.randomizationFactor = randomizationFactor;
+    }
+
+    public Duration getInitialInterval() {
+        return initialInterval;
+    }
+
+    public void setInitialInterval(Duration initialInterval) {
+        this.initialInterval = initialInterval;
+    }
+}

--- a/src/main/java/com/homeaway/dropwizard/bundle/resilience4j/configuration/retry/IntervalFunctionFactory.java
+++ b/src/main/java/com/homeaway/dropwizard/bundle/resilience4j/configuration/retry/IntervalFunctionFactory.java
@@ -1,0 +1,33 @@
+package com.homeaway.dropwizard.bundle.resilience4j.configuration.retry;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import io.dropwizard.jackson.Discoverable;
+import io.github.resilience4j.retry.IntervalFunction;
+
+/**
+ * A service provider interface for creating Resilience4j {@link IntervalFunction interval functions}.
+ * To create your own, just:
+ * <ol>
+ *     <li>Create a class which implements {@link IntervalFunctionFactory}.</li>
+ *     <li>Annotate it with {@code @JsonTypeName} and give it a unique type name.</li>
+ *     <li>Add it to the {@code @JsonSubTypes} annotation on this class</li>
+ * </ol>
+ *
+ * @see ConstantIntervalFunctionFactory
+ * @see ExponentialBackoffFunctionFactory
+ * @see ExponentialRandomBackoffFunctionFactory
+ * @see RandomizedIntervalFunctionFactory
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = ConstantIntervalFunctionFactory.class),
+    @JsonSubTypes.Type(value = ExponentialBackoffFunctionFactory.class),
+    @JsonSubTypes.Type(value = ExponentialRandomBackoffFunctionFactory.class),
+    @JsonSubTypes.Type(value = RandomizedIntervalFunctionFactory.class)
+})
+public interface IntervalFunctionFactory extends Discoverable {
+
+    IntervalFunction build();
+}

--- a/src/main/java/com/homeaway/dropwizard/bundle/resilience4j/configuration/retry/RandomizedIntervalFunctionFactory.java
+++ b/src/main/java/com/homeaway/dropwizard/bundle/resilience4j/configuration/retry/RandomizedIntervalFunctionFactory.java
@@ -1,0 +1,48 @@
+package com.homeaway.dropwizard.bundle.resilience4j.configuration.retry;
+
+import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import io.dropwizard.util.Duration;
+import io.github.resilience4j.retry.IntervalFunction;
+
+@JsonTypeName("randomized")
+public class RandomizedIntervalFunctionFactory implements IntervalFunctionFactory {
+
+    /**
+     * Base interval before randomization is applied. Minimum value is 10 milliseconds. Default is R4j default, currently 500ms.
+     */
+    @JsonProperty
+    @NotNull
+    private Duration initialInterval = Duration.milliseconds(IntervalFunction.DEFAULT_INITIAL_INTERVAL);
+
+    /**
+     * Randomization multiplier. Must be in range [0.0d, 1.0d)
+     */
+    @JsonProperty
+    @NotNull
+    private double randomizationFactor = IntervalFunction.DEFAULT_RANDOMIZATION_FACTOR;
+
+    @Override
+    public IntervalFunction build() {
+       return IntervalFunction.ofRandomized(initialInterval.toMilliseconds(), randomizationFactor);
+    }
+
+    public Duration getInitialInterval() {
+        return initialInterval;
+    }
+
+    public void setInitialInterval(Duration initialInterval) {
+        this.initialInterval = initialInterval;
+    }
+
+    public double getRandomizationFactor() {
+        return randomizationFactor;
+    }
+
+    public void setRandomizationFactor(double randomizationFactor) {
+        this.randomizationFactor = randomizationFactor;
+    }
+}

--- a/src/main/java/com/homeaway/dropwizard/bundle/resilience4j/configuration/retry/RetryConfiguration.java
+++ b/src/main/java/com/homeaway/dropwizard/bundle/resilience4j/configuration/retry/RetryConfiguration.java
@@ -1,0 +1,98 @@
+package com.homeaway.dropwizard.bundle.resilience4j.configuration.retry;
+
+import javax.validation.constraints.NotNull;
+
+import org.hibernate.validator.constraints.NotEmpty;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.github.resilience4j.retry.RetryConfig;
+
+public class RetryConfiguration {
+
+    /**
+     * Name for this circuit breaker for use in the registry
+     */
+    @JsonProperty
+    @NotEmpty
+    private String name;
+
+    /**
+     * Names of exceptions to ignore
+     */
+    @JsonProperty
+    private Class[] ignoreExceptions = null;
+
+    /**
+     * Names of exceptions to always retry
+     */
+    @JsonProperty
+    private Class[] retryExceptions = null;
+
+    /**
+     * Maximum number of retries
+     */
+    @JsonProperty
+    private int maxAttempts = 3;
+
+    /**
+     * Interval function to define wait period between attempts
+     */
+    @JsonProperty
+    @NotNull
+    private IntervalFunctionFactory intervalFunction;
+
+    public RetryConfig.Builder toResilience4jConfigBuilder() {
+        final RetryConfig.Builder builder = new RetryConfig.Builder()
+            .maxAttempts(this.maxAttempts)
+            .intervalFunction(intervalFunction.build())
+            .ignoreExceptions(ignoreExceptions)
+            .retryExceptions(retryExceptions);
+
+        //We are intentionally not supporting the waitDuration() setting, because under the covers it just sets a constant-duration intervalFunction
+        //The bundle's approach to that is to use a ConstantIntervalFunctionFactory instead
+        //builder.waitDuration(foo);
+
+        return builder;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Class[] getIgnoreExceptions() {
+        return ignoreExceptions;
+    }
+
+    public void setIgnoreExceptions(Class[] ignoreExceptions) {
+        this.ignoreExceptions = ignoreExceptions;
+    }
+
+    public Class[] getRetryExceptions() {
+        return retryExceptions;
+    }
+
+    public void setRetryExceptions(Class[] retryExceptions) {
+        this.retryExceptions = retryExceptions;
+    }
+
+    public int getMaxAttempts() {
+        return maxAttempts;
+    }
+
+    public void setMaxAttempts(int maxAttempts) {
+        this.maxAttempts = maxAttempts;
+    }
+
+    public IntervalFunctionFactory getIntervalFunction() {
+        return intervalFunction;
+    }
+
+    public void setIntervalFunction(IntervalFunctionFactory intervalFunction) {
+        this.intervalFunction = intervalFunction;
+    }
+}

--- a/src/main/java/com/homeaway/dropwizard/bundle/resilience4j/configuration/retry/RetryConfiguration.java
+++ b/src/main/java/com/homeaway/dropwizard/bundle/resilience4j/configuration/retry/RetryConfiguration.java
@@ -21,13 +21,13 @@ public class RetryConfiguration {
      * Names of exceptions to ignore
      */
     @JsonProperty
-    private Class[] ignoreExceptions = null;
+    private Class<? extends Throwable>[] ignoreExceptions = null;
 
     /**
      * Names of exceptions to always retry
      */
     @JsonProperty
-    private Class[] retryExceptions = null;
+    private Class<? extends Throwable>[] retryExceptions = null;
 
     /**
      * Maximum number of retries
@@ -64,19 +64,19 @@ public class RetryConfiguration {
         this.name = name;
     }
 
-    public Class[] getIgnoreExceptions() {
+    public Class<? extends Throwable>[] getIgnoreExceptions() {
         return ignoreExceptions;
     }
 
-    public void setIgnoreExceptions(Class[] ignoreExceptions) {
+    public void setIgnoreExceptions(Class<? extends Throwable>[] ignoreExceptions) {
         this.ignoreExceptions = ignoreExceptions;
     }
 
-    public Class[] getRetryExceptions() {
+    public Class<? extends Throwable>[] getRetryExceptions() {
         return retryExceptions;
     }
 
-    public void setRetryExceptions(Class[] retryExceptions) {
+    public void setRetryExceptions(Class<? extends Throwable>[] retryExceptions) {
         this.retryExceptions = retryExceptions;
     }
 

--- a/src/test/java/com/homeaway/dropwizard/bundle/resilience4j/Resilience4jBundleTest.java
+++ b/src/test/java/com/homeaway/dropwizard/bundle/resilience4j/Resilience4jBundleTest.java
@@ -20,11 +20,17 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang3.tuple.Pair;
-import com.homeaway.dropwizard.bundle.resilience4j.configuration.CircuitBreakerConfiguration;
-import com.homeaway.dropwizard.bundle.resilience4j.configuration.Resilience4jConfiguration;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import com.homeaway.dropwizard.bundle.resilience4j.configuration.CircuitBreakerConfiguration;
+import com.homeaway.dropwizard.bundle.resilience4j.configuration.Resilience4jConfiguration;
+import com.homeaway.dropwizard.bundle.resilience4j.configuration.retry.ConstantIntervalFunctionFactory;
+import com.homeaway.dropwizard.bundle.resilience4j.configuration.retry.ExponentialBackoffFunctionFactory;
+import com.homeaway.dropwizard.bundle.resilience4j.configuration.retry.ExponentialRandomBackoffFunctionFactory;
+import com.homeaway.dropwizard.bundle.resilience4j.configuration.retry.RandomizedIntervalFunctionFactory;
+import com.homeaway.dropwizard.bundle.resilience4j.configuration.retry.RetryConfiguration;
 
 import io.dropwizard.Application;
 import io.dropwizard.Configuration;
@@ -34,6 +40,7 @@ import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import io.dropwizard.util.Duration;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import io.github.resilience4j.retry.RetryConfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -42,7 +49,6 @@ public class Resilience4jBundleTest {
     @Rule
     public DropwizardAppRule<TestConfiguration> app =
         new DropwizardAppRule<>(TestApplication.class, ResourceHelpers.resourceFilePath("config.yaml"));
-
 
     @Before
     public void setup() {
@@ -59,16 +65,45 @@ public class Resilience4jBundleTest {
         assertThat(breaker1).isNotNull();
         assertThat(breaker1.getName()).isEqualTo("testBreaker1");
         assertThat(breaker1.getEnableAutomaticTransitionFromOpenToHalfOpen()).isFalse();
-        assertThat(breaker1.getFailureRateThreshold()).isEqualTo(10);
-        assertThat(breaker1.getRingBufferSizeInClosedState()).isEqualTo(50);
-        assertThat(breaker1.getRingBufferSizeInHalfOpenState()).isEqualTo(5);
         assertThat(breaker1.getWaitDurationInOpenState()).isEqualTo(Duration.seconds(30));
+        assertThat(breaker1.getFailureRateThreshold()).isEqualTo(10);
+        assertThat(breaker1.getMinimumNumberOfCalls()).isEqualTo(5);
+        assertThat(breaker1.getPermittedNumberOfCallsInHalfOpenState()).isEqualTo(2);
+        assertThat(breaker1.getSlidingWindowSize()).isEqualTo(4);
+        assertThat(breaker1.getSlidingWindowType()).isEqualTo(CircuitBreakerConfig.SlidingWindowType.TIME_BASED);
+        assertThat(breaker1.getSlowCallRateThreshold()).isEqualTo(1.5f);
+        assertThat(breaker1.getSlowCallDurationThreshold()).isEqualTo(Duration.milliseconds(10));
+        assertThat(breaker1.isWritableStackTraceEnabled()).isEqualTo(true);
+        assertThat(breaker1.getIgnoreExceptions()).containsExactly(NullPointerException.class);
+        assertThat(breaker1.getRecordExceptions()).containsExactly(IllegalArgumentException.class);
 
-        assertThat(r4jConfig.getCircuitBreakers().get(1).getName()).isEqualTo("testBreaker2");
-        assertThat(r4jConfig.getCircuitBreakers().get(2).getName()).isEqualTo("testBreaker3");
+        CircuitBreakerConfiguration breaker2 = r4jConfig.getCircuitBreakers().get(1);
+        assertThat(breaker2).isNotNull();
+        assertThat(breaker2.getName()).isEqualTo("testBreaker2");
+        assertThat(breaker2.getEnableAutomaticTransitionFromOpenToHalfOpen()).isTrue();
+        assertThat(breaker2.getWaitDurationInOpenState()).isEqualTo(Duration.seconds(CircuitBreakerConfig.DEFAULT_WAIT_DURATION_IN_OPEN_STATE));
+        assertThat(breaker2.getFailureRateThreshold()).isEqualTo(CircuitBreakerConfig.DEFAULT_FAILURE_RATE_THRESHOLD);
+        assertThat(breaker2.getMinimumNumberOfCalls()).isEqualTo(CircuitBreakerConfig.DEFAULT_MINIMUM_NUMBER_OF_CALLS);
+        assertThat(breaker2.getPermittedNumberOfCallsInHalfOpenState()).isEqualTo(CircuitBreakerConfig.DEFAULT_PERMITTED_CALLS_IN_HALF_OPEN_STATE);
+        assertThat(breaker2.getSlidingWindowSize()).isEqualTo(CircuitBreakerConfig.DEFAULT_SLIDING_WINDOW_SIZE);
+        assertThat(breaker2.getSlidingWindowType()).isEqualTo(CircuitBreakerConfig.DEFAULT_SLIDING_WINDOW_TYPE);
+        assertThat(breaker2.getSlowCallRateThreshold()).isEqualTo(CircuitBreakerConfig.DEFAULT_SLOW_CALL_RATE_THRESHOLD);
+        assertThat(breaker2.getSlowCallDurationThreshold()).isEqualTo(Duration.seconds(CircuitBreakerConfig.DEFAULT_SLOW_CALL_DURATION_THRESHOLD));
+        assertThat(breaker2.isWritableStackTraceEnabled()).isEqualTo(true);
+        assertThat(breaker2.getIgnoreExceptions()).isNullOrEmpty();
+        assertThat(breaker2.getRecordExceptions()).isNullOrEmpty();
+
+        CircuitBreakerConfiguration breaker3 = r4jConfig.getCircuitBreakers().get(2);
+        assertThat(breaker3).isNotNull();
+        assertThat(breaker3.getName()).isEqualTo("testBreaker3");
+        assertThat(breaker3.getSlidingWindowSize()).isEqualTo(10);
+        assertThat(breaker3.getSlidingWindowType()).isEqualTo(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED);
+        assertThat(breaker2.getIgnoreExceptions()).isNullOrEmpty();
+        assertThat(breaker2.getRecordExceptions()).isNullOrEmpty();
 
         //Check that the configurator function was called for each breaker config
-        List<Pair<String, CircuitBreakerConfig.Builder>> breakersSeenInConfiguration = ((TestApplication)app.getApplication()).getBreakersSeenInConfiguration();
+        List<Pair<String, CircuitBreakerConfig.Builder>> breakersSeenInConfiguration =
+            ((TestApplication) app.getApplication()).getBreakersSeenInConfiguration();
         assertThat(breakersSeenInConfiguration.size()).isEqualTo(3);
         assertThat(breakersSeenInConfiguration.get(0).getKey()).isEqualTo("testBreaker1");
         assertThat(breakersSeenInConfiguration.get(1).getKey()).isEqualTo("testBreaker2");
@@ -77,6 +112,42 @@ public class Resilience4jBundleTest {
         assertThat(r4jConfig.getCircuitBreakerRegistry().circuitBreaker("testBreaker1")).isNotNull();
         assertThat(r4jConfig.getCircuitBreakerRegistry().circuitBreaker("testBreaker2")).isNotNull();
         assertThat(r4jConfig.getCircuitBreakerRegistry().circuitBreaker("testBreaker3")).isNotNull();
+
+        //Check that retry was configured correctly
+        assertThat(r4jConfig.getRetryConfigurations()).isNotNull();
+        assertThat(r4jConfig.getRetryConfigurations().size()).isEqualTo(4);
+
+        RetryConfiguration retry1 = r4jConfig.getRetryConfigurations().get(0);
+        assertThat(retry1).isNotNull();
+        assertThat(retry1.getName()).isEqualTo("constantRetry");
+        assertThat(retry1.getMaxAttempts()).isEqualTo(1);
+        assertThat(retry1.getIgnoreExceptions()).containsExactly(RuntimeException.class);
+        assertThat(retry1.getRetryExceptions()).containsExactly(IllegalArgumentException.class);
+        assertThat(retry1.getIntervalFunction().getClass()).isEqualTo(ConstantIntervalFunctionFactory.class);
+
+        RetryConfiguration retry2 = r4jConfig.getRetryConfigurations().get(1);
+        assertThat(retry2).isNotNull();
+        assertThat(retry2.getName()).isEqualTo("randomizedRetry");
+        assertThat(retry2.getMaxAttempts()).isEqualTo(2);
+        assertThat(retry2.getIgnoreExceptions()).isNullOrEmpty();
+        assertThat(retry2.getRetryExceptions()).isNullOrEmpty();
+        assertThat(retry2.getIntervalFunction().getClass()).isEqualTo(RandomizedIntervalFunctionFactory.class);
+
+        RetryConfiguration retry3 = r4jConfig.getRetryConfigurations().get(2);
+        assertThat(retry3).isNotNull();
+        assertThat(retry3.getName()).isEqualTo("exponentialBackoffRetry");
+        assertThat(retry3.getMaxAttempts()).isEqualTo(3);
+        assertThat(retry3.getIgnoreExceptions()).isNullOrEmpty();
+        assertThat(retry3.getRetryExceptions()).isNullOrEmpty();
+        assertThat(retry3.getIntervalFunction().getClass()).isEqualTo(ExponentialBackoffFunctionFactory.class);
+
+        RetryConfiguration retry4 = r4jConfig.getRetryConfigurations().get(3);
+        assertThat(retry4).isNotNull();
+        assertThat(retry4.getName()).isEqualTo("exponentialRandomizedBackoffRetry");
+        assertThat(retry4.getMaxAttempts()).isEqualTo(4);
+        assertThat(retry4.getIgnoreExceptions()).isNullOrEmpty();
+        assertThat(retry4.getRetryExceptions()).isNullOrEmpty();
+        assertThat(retry4.getIntervalFunction().getClass()).isEqualTo(ExponentialRandomBackoffFunctionFactory.class);
     }
 
     public static class TestConfiguration extends Configuration {
@@ -92,9 +163,14 @@ public class Resilience4jBundleTest {
 
         private List<Pair<String, CircuitBreakerConfig.Builder>> breakersSeenInConfiguration = new ArrayList<>();
 
+        private List<Pair<String, RetryConfig.Builder>> retryersSeenInConfiguration = new ArrayList<>();
+
         @Override
         public void initialize(Bootstrap<TestConfiguration> bootstrap) {
-            Resilience4jBundle<TestConfiguration> bundle = new Resilience4jBundle<>(TestConfiguration::getResilience4j, this::addBreakerConfigurationToTestList);
+            Resilience4jBundle<TestConfiguration> bundle =
+                new Resilience4jBundle<>(TestConfiguration::getResilience4j,
+                                         this::addBreakerConfigurationToTestList,
+                                         this::addRetryConfigurationToTestList);
 
             bootstrap.addBundle(bundle);
         }
@@ -107,8 +183,16 @@ public class Resilience4jBundleTest {
             breakersSeenInConfiguration.add(Pair.of(key, builder));
         }
 
+        private void addRetryConfigurationToTestList(String key, RetryConfig.Builder builder) {
+            retryersSeenInConfiguration.add(Pair.of(key, builder));
+        }
+
         public List<Pair<String, CircuitBreakerConfig.Builder>> getBreakersSeenInConfiguration() {
             return breakersSeenInConfiguration;
+        }
+
+        public List<Pair<String, RetryConfig.Builder>> getRetryersSeenInConfiguration() {
+            return retryersSeenInConfiguration;
         }
     }
 }

--- a/src/test/resources/config.yaml
+++ b/src/test/resources/config.yaml
@@ -9,10 +9,55 @@ server:
 resilience4j:
     circuitBreakers:
         - name: testBreaker1
-          failureRateThreshold: 10
-          ringBufferSizeInHalfOpenState: 5
-          ringBufferSizeInClosedState: 50
           waitDurationInOpenState: 30s
           enableAutomaticTransitionFromOpenToHalfOpen: false
+          failureRateThreshold: 10
+          minimumNumberOfCalls: 5
+          permittedNumberOfCallsInHalfOpenState: 2
+          slidingWindowSize: 4
+          slidingWindowType: TIME_BASED
+          slowCallDurationThreshold: 10ms
+          slowCallRateThreshold: 1.5
+          writableStackTraceEnabled: true
+          ignoreExceptions:
+            - java.lang.NullPointerException
+          recordExceptions:
+            - java.lang.IllegalArgumentException
         - name: testBreaker2
         - name: testBreaker3
+          slidingWindowType: COUNT_BASED
+          slidingWindowSize: 10
+          ignoreExceptions:
+          recordExceptions:
+
+    retryConfigurations:
+      - name: constantRetry
+        maxAttempts: 1
+        intervalFunction:
+          type: constant
+          initialInterval: 10ms
+        ignoreExceptions:
+          - java.lang.RuntimeException
+        retryExceptions:
+          - java.lang.IllegalArgumentException
+      - name: randomizedRetry
+        maxAttempts: 2
+        intervalFunction:
+          type: randomized
+          initialInterval: 10ms
+          randomizationFactor: 0.5
+        ignoreExceptions:
+        retryExceptions:
+      - name: exponentialBackoffRetry
+        maxAttempts: 3
+        intervalFunction:
+          type: exponentialBackoff
+          initialInterval: 10ms
+          multiplier: 3.5
+      - name: exponentialRandomizedBackoffRetry
+        maxAttempts: 4
+        intervalFunction:
+          type: exponentialRandomBackoff
+          initialInterval: 10ms
+          multiplier: 2.5
+          randomizationFactor: 0.5


### PR DESCRIPTION
I started out trying to implement support for R4j's `Retry` feature, which is in here. But I also bumped us up to Resilience4j v1.1.0, which is a pretty major change from the previous version. Therefore this is a breaking change from the previous version. 

*Added*
- Support for R4j `Retry` feature. 

*Changed*
- Updated to R4j v1.1.0, which is pretty majorly breaking from previous versions
- Updated configs for CircuitBreakers to match new version of R4j, which is also breaking from previous configs (ie, some YAML configs that worked before won't anymore)
- Update `README.MD`

*Deleted*
- nothing

*PR Checklist Forms*
 CHANGELOG.md updated
 Unit test(s) added
 Reviewer assigned
 PR assigned (presumably to submitter)
 Labels added (enhancement, bug, documentation)