### PR TITLE
Attach Javadocs to jar and fix warnings in some doc blocks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,19 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>${source.pluginVersion}</version>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/src/main/java/com/homeaway/dropwizard/bundle/resilience4j/Resilience4jBundle.java
+++ b/src/main/java/com/homeaway/dropwizard/bundle/resilience4j/Resilience4jBundle.java
@@ -51,6 +51,8 @@ public class Resilience4jBundle<T> implements ConfiguredBundle<T> {
 
     /**
      * Create a new bundle
+     *
+     * @param resilienceConfiguratorFunction Function to extract the Resilience4j configuration from the dropwizard configuration
      */
     public Resilience4jBundle(@NonNull Function<T, Resilience4jConfiguration> resilienceConfiguratorFunction) {
         this(resilienceConfiguratorFunction,
@@ -61,7 +63,9 @@ public class Resilience4jBundle<T> implements ConfiguredBundle<T> {
     /**
      * Create a new bundle, with a function for modifying CircuitBreaker configurations
      *
+     * @param resilienceConfiguratorFunction Function to extract the Resilience4j configuration from the dropwizard configuration
      * @param circuitBreakerConfigurator A function that will be passed the name and builder for each circuit breaker before it is created
+     * @param retryConfigurator A function that will be passed the name and builder for each retryer
      */
     public Resilience4jBundle(@NonNull Function<T, Resilience4jConfiguration> resilienceConfiguratorFunction,
                               @NonNull BiConsumer<String, CircuitBreakerConfig.Builder> circuitBreakerConfigurator,


### PR DESCRIPTION
# resilience4j dropwizard bundle PR

Attach Javadocs to jar and fix warnings in some doc blocks

### Added
* Javadocs to jar

# PR Checklist Forms

- [ ] CHANGELOG.md updated
- [ ] Unit test(s) added
- [ ] Reviewer assigned
- [ ] PR assigned (presumably to submitter)
- [ ] Labels added (enhancement, bug, documentation)
