### PR TITLE
Relocate classes and rename artifact groupId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## [Unreleased]
-### Added
+## [2.0.0] - TBD
+### Changed
+- Renamed artifact groupId from `com.expediagroup.dropwizard.bundle` to `com.expediagroup`
+- Relocated classes from `com.homeaway.dropwizard.bundle.resilience4j` to `com.expediagroup.dropwizard.resilience4j`
 
+## [1.0.1] - 2019-10-31
 ### Changed
 - Fixed crash at startup when no `retryConfigurations` are specified in the config
-
 
 ## [1.0.0] - 2019-10-27
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ User Guide
 In your POM...
 ```xml
 <dependency>
-    <groupId>com.expediagroup.dropwizard.bundle</groupId>
+    <groupId>com.expediagroup</groupId>
     <artifactId>dropwizard-resilience4j-bundle</artifactId>
     <version>0.1.0</version> <!-- use latest -->
 </dependency>
@@ -51,7 +51,7 @@ Add to your application's Config class:
 private Resilience4jConfiguration resilience4j;
 ```
 
-Configured R4J objects are automatically wired into Dropwizard Metrics, and also [into HK2 using the name from the YAML](src/main/java/com/homeaway/dropwizard/bundle/resilience4j/Resilience4jBundle.java#L93).
+Configured R4J objects are automatically wired into Dropwizard Metrics, and also [into HK2 using the name from the YAML](src/main/java/com/expediagroup/dropwizard/resilience4j/Resilience4jBundle.java#L93).
 You can also retrieve them from the configuration class...
 
 ```java

--- a/pom.xml
+++ b/pom.xml
@@ -3,9 +3,9 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.expediagroup.dropwizard.bundle</groupId>
+    <groupId>com.expediagroup</groupId>
     <artifactId>dropwizard-resilience4j-bundle</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>dropwizard-resilience4j-bundle</name>

--- a/src/main/java/com/expediagroup/dropwizard/resilience4j/Resilience4jBundle.java
+++ b/src/main/java/com/expediagroup/dropwizard/resilience4j/Resilience4jBundle.java
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
  */
 
-package com.homeaway.dropwizard.bundle.resilience4j;
+package com.expediagroup.dropwizard.resilience4j;
 
 import java.util.List;
 import java.util.function.BiConsumer;
@@ -22,9 +22,9 @@ import java.util.function.Function;
 
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 
-import com.homeaway.dropwizard.bundle.resilience4j.configuration.CircuitBreakerConfiguration;
-import com.homeaway.dropwizard.bundle.resilience4j.configuration.Resilience4jConfiguration;
-import com.homeaway.dropwizard.bundle.resilience4j.configuration.retry.RetryConfiguration;
+import com.expediagroup.dropwizard.resilience4j.configuration.CircuitBreakerConfiguration;
+import com.expediagroup.dropwizard.resilience4j.configuration.Resilience4jConfiguration;
+import com.expediagroup.dropwizard.resilience4j.configuration.retry.RetryConfiguration;
 
 import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.setup.Bootstrap;

--- a/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/CircuitBreakerConfiguration.java
+++ b/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/CircuitBreakerConfiguration.java
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
  */
 
-package com.homeaway.dropwizard.bundle.resilience4j.configuration;
+package com.expediagroup.dropwizard.resilience4j.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/Resilience4jConfiguration.java
+++ b/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/Resilience4jConfiguration.java
@@ -14,14 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
  */
 
-package com.homeaway.dropwizard.bundle.resilience4j.configuration;
+package com.expediagroup.dropwizard.resilience4j.configuration;
 
 import java.util.List;
 
 import javax.annotation.Nullable;
 import javax.validation.Valid;
 
-import com.homeaway.dropwizard.bundle.resilience4j.configuration.retry.RetryConfiguration;
+import com.expediagroup.dropwizard.resilience4j.configuration.retry.RetryConfiguration;
 
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.retry.RetryRegistry;

--- a/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/retry/ConstantIntervalFunctionFactory.java
+++ b/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/retry/ConstantIntervalFunctionFactory.java
@@ -1,4 +1,4 @@
-package com.homeaway.dropwizard.bundle.resilience4j.configuration.retry;
+package com.expediagroup.dropwizard.resilience4j.configuration.retry;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;

--- a/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/retry/ExponentialBackoffFunctionFactory.java
+++ b/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/retry/ExponentialBackoffFunctionFactory.java
@@ -1,4 +1,4 @@
-package com.homeaway.dropwizard.bundle.resilience4j.configuration.retry;
+package com.expediagroup.dropwizard.resilience4j.configuration.retry;
 
 import javax.validation.constraints.NotNull;
 
@@ -8,22 +8,15 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.dropwizard.util.Duration;
 import io.github.resilience4j.retry.IntervalFunction;
 
-@JsonTypeName("exponentialRandomBackoff")
-public class ExponentialRandomBackoffFunctionFactory implements IntervalFunctionFactory {
+@JsonTypeName("exponentialBackoff")
+public class ExponentialBackoffFunctionFactory implements IntervalFunctionFactory {
 
     /**
-     * Amount to multiply by at each iteration. Must be greater than 1. Default value is 1.5.
+     * Amount to multiply by at each iteration. Must be greater than 1.  Default value is 1.5.
      */
     @JsonProperty
     @NotNull
     private double multiplier = IntervalFunction.DEFAULT_MULTIPLIER;
-
-    /**
-     * Randomization multiplier. Must be in range [0.0d, 1.0d). Default value is 0.5.
-     */
-    @JsonProperty
-    @NotNull
-    private double randomizationFactor = IntervalFunction.DEFAULT_RANDOMIZATION_FACTOR;
 
     /**
      * Initial interval. Minimum value is 10 milliseconds. Default is R4j default, currently 500ms.
@@ -34,7 +27,7 @@ public class ExponentialRandomBackoffFunctionFactory implements IntervalFunction
 
     @Override
     public IntervalFunction build() {
-        return IntervalFunction.ofExponentialRandomBackoff(initialInterval.toMilliseconds(), multiplier, randomizationFactor);
+        return IntervalFunction.ofExponentialBackoff(initialInterval.toMilliseconds(), multiplier);
     }
 
     public double getMultiplier() {
@@ -43,14 +36,6 @@ public class ExponentialRandomBackoffFunctionFactory implements IntervalFunction
 
     public void setMultiplier(double multiplier) {
         this.multiplier = multiplier;
-    }
-
-    public double getRandomizationFactor() {
-        return randomizationFactor;
-    }
-
-    public void setRandomizationFactor(double randomizationFactor) {
-        this.randomizationFactor = randomizationFactor;
     }
 
     public Duration getInitialInterval() {

--- a/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/retry/ExponentialRandomBackoffFunctionFactory.java
+++ b/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/retry/ExponentialRandomBackoffFunctionFactory.java
@@ -1,4 +1,4 @@
-package com.homeaway.dropwizard.bundle.resilience4j.configuration.retry;
+package com.expediagroup.dropwizard.resilience4j.configuration.retry;
 
 import javax.validation.constraints.NotNull;
 
@@ -8,15 +8,22 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.dropwizard.util.Duration;
 import io.github.resilience4j.retry.IntervalFunction;
 
-@JsonTypeName("exponentialBackoff")
-public class ExponentialBackoffFunctionFactory implements IntervalFunctionFactory {
+@JsonTypeName("exponentialRandomBackoff")
+public class ExponentialRandomBackoffFunctionFactory implements IntervalFunctionFactory {
 
     /**
-     * Amount to multiply by at each iteration. Must be greater than 1.  Default value is 1.5.
+     * Amount to multiply by at each iteration. Must be greater than 1. Default value is 1.5.
      */
     @JsonProperty
     @NotNull
     private double multiplier = IntervalFunction.DEFAULT_MULTIPLIER;
+
+    /**
+     * Randomization multiplier. Must be in range [0.0d, 1.0d). Default value is 0.5.
+     */
+    @JsonProperty
+    @NotNull
+    private double randomizationFactor = IntervalFunction.DEFAULT_RANDOMIZATION_FACTOR;
 
     /**
      * Initial interval. Minimum value is 10 milliseconds. Default is R4j default, currently 500ms.
@@ -27,7 +34,7 @@ public class ExponentialBackoffFunctionFactory implements IntervalFunctionFactor
 
     @Override
     public IntervalFunction build() {
-        return IntervalFunction.ofExponentialBackoff(initialInterval.toMilliseconds(), multiplier);
+        return IntervalFunction.ofExponentialRandomBackoff(initialInterval.toMilliseconds(), multiplier, randomizationFactor);
     }
 
     public double getMultiplier() {
@@ -36,6 +43,14 @@ public class ExponentialBackoffFunctionFactory implements IntervalFunctionFactor
 
     public void setMultiplier(double multiplier) {
         this.multiplier = multiplier;
+    }
+
+    public double getRandomizationFactor() {
+        return randomizationFactor;
+    }
+
+    public void setRandomizationFactor(double randomizationFactor) {
+        this.randomizationFactor = randomizationFactor;
     }
 
     public Duration getInitialInterval() {

--- a/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/retry/IntervalFunctionFactory.java
+++ b/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/retry/IntervalFunctionFactory.java
@@ -1,4 +1,4 @@
-package com.homeaway.dropwizard.bundle.resilience4j.configuration.retry;
+package com.expediagroup.dropwizard.resilience4j.configuration.retry;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;

--- a/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/retry/RandomizedIntervalFunctionFactory.java
+++ b/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/retry/RandomizedIntervalFunctionFactory.java
@@ -1,4 +1,4 @@
-package com.homeaway.dropwizard.bundle.resilience4j.configuration.retry;
+package com.expediagroup.dropwizard.resilience4j.configuration.retry;
 
 import javax.validation.constraints.NotNull;
 

--- a/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/retry/RetryConfiguration.java
+++ b/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/retry/RetryConfiguration.java
@@ -1,4 +1,4 @@
-package com.homeaway.dropwizard.bundle.resilience4j.configuration.retry;
+package com.expediagroup.dropwizard.resilience4j.configuration.retry;
 
 import javax.validation.constraints.NotNull;
 

--- a/src/test/java/com/expediagroup/dropwizard/resilience4j/ResourceTestUtil.java
+++ b/src/test/java/com/expediagroup/dropwizard/resilience4j/ResourceTestUtil.java
@@ -1,4 +1,4 @@
-package com.homeaway.dropwizard.bundle.resilience4j;
+package com.expediagroup.dropwizard.resilience4j;
 
 import java.io.File;
 import java.net.URI;

--- a/src/test/java/com/expediagroup/dropwizard/resilience4j/TestApplication.java
+++ b/src/test/java/com/expediagroup/dropwizard/resilience4j/TestApplication.java
@@ -1,4 +1,4 @@
-package com.homeaway.dropwizard.bundle.resilience4j;
+package com.expediagroup.dropwizard.resilience4j;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/com/expediagroup/dropwizard/resilience4j/TestConfiguration.java
+++ b/src/test/java/com/expediagroup/dropwizard/resilience4j/TestConfiguration.java
@@ -1,6 +1,6 @@
-package com.homeaway.dropwizard.bundle.resilience4j;
+package com.expediagroup.dropwizard.resilience4j;
 
-import com.homeaway.dropwizard.bundle.resilience4j.configuration.Resilience4jConfiguration;
+import com.expediagroup.dropwizard.resilience4j.configuration.Resilience4jConfiguration;
 
 import io.dropwizard.Configuration;
 

--- a/src/test/java/com/expediagroup/dropwizard/resilience4j/circuitbreaker/CircuitBreakerConfigTest.java
+++ b/src/test/java/com/expediagroup/dropwizard/resilience4j/circuitbreaker/CircuitBreakerConfigTest.java
@@ -1,4 +1,4 @@
-package com.homeaway.dropwizard.bundle.resilience4j.circuitbreaker;
+package com.expediagroup.dropwizard.resilience4j.circuitbreaker;
 
 import java.util.List;
 
@@ -6,11 +6,11 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Rule;
 import org.junit.Test;
 
-import com.homeaway.dropwizard.bundle.resilience4j.ResourceTestUtil;
-import com.homeaway.dropwizard.bundle.resilience4j.TestApplication;
-import com.homeaway.dropwizard.bundle.resilience4j.TestConfiguration;
-import com.homeaway.dropwizard.bundle.resilience4j.configuration.CircuitBreakerConfiguration;
-import com.homeaway.dropwizard.bundle.resilience4j.configuration.Resilience4jConfiguration;
+import com.expediagroup.dropwizard.resilience4j.configuration.CircuitBreakerConfiguration;
+import com.expediagroup.dropwizard.resilience4j.configuration.Resilience4jConfiguration;
+import com.expediagroup.dropwizard.resilience4j.ResourceTestUtil;
+import com.expediagroup.dropwizard.resilience4j.TestApplication;
+import com.expediagroup.dropwizard.resilience4j.TestConfiguration;
 
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import io.dropwizard.util.Duration;

--- a/src/test/java/com/expediagroup/dropwizard/resilience4j/retry/RetryConfigTest.java
+++ b/src/test/java/com/expediagroup/dropwizard/resilience4j/retry/RetryConfigTest.java
@@ -1,17 +1,18 @@
-package com.homeaway.dropwizard.bundle.resilience4j.retry;
+package com.expediagroup.dropwizard.resilience4j.retry;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Rule;
 import org.junit.Test;
 
-import com.homeaway.dropwizard.bundle.resilience4j.ResourceTestUtil;
-import com.homeaway.dropwizard.bundle.resilience4j.TestApplication;
-import com.homeaway.dropwizard.bundle.resilience4j.TestConfiguration;
-import com.homeaway.dropwizard.bundle.resilience4j.configuration.Resilience4jConfiguration;
-import com.homeaway.dropwizard.bundle.resilience4j.configuration.retry.ConstantIntervalFunctionFactory;
-import com.homeaway.dropwizard.bundle.resilience4j.configuration.retry.ExponentialBackoffFunctionFactory;
-import com.homeaway.dropwizard.bundle.resilience4j.configuration.retry.ExponentialRandomBackoffFunctionFactory;
-import com.homeaway.dropwizard.bundle.resilience4j.configuration.retry.RandomizedIntervalFunctionFactory;
-import com.homeaway.dropwizard.bundle.resilience4j.configuration.retry.RetryConfiguration;
+import com.expediagroup.dropwizard.resilience4j.configuration.Resilience4jConfiguration;
+import com.expediagroup.dropwizard.resilience4j.configuration.retry.ConstantIntervalFunctionFactory;
+import com.expediagroup.dropwizard.resilience4j.configuration.retry.RetryConfiguration;
+import com.expediagroup.dropwizard.resilience4j.ResourceTestUtil;
+import com.expediagroup.dropwizard.resilience4j.TestApplication;
+import com.expediagroup.dropwizard.resilience4j.TestConfiguration;
+import com.expediagroup.dropwizard.resilience4j.configuration.retry.ExponentialBackoffFunctionFactory;
+import com.expediagroup.dropwizard.resilience4j.configuration.retry.ExponentialRandomBackoffFunctionFactory;
+import com.expediagroup.dropwizard.resilience4j.configuration.retry.RandomizedIntervalFunctionFactory;
 
 import io.dropwizard.testing.junit.DropwizardAppRule;
 
@@ -28,7 +29,7 @@ public class RetryConfigTest {
         Resilience4jConfiguration r4jConfig = app.getConfiguration().getResilience4j();
 
         //Check that retry was configured correctly
-        assertThat(r4jConfig.getRetryConfigurations()).isNotNull();
+        Assertions.assertThat(r4jConfig.getRetryConfigurations()).isNotNull();
         assertThat(r4jConfig.getRetryConfigurations().size()).isEqualTo(4);
 
         RetryConfiguration retry1 = r4jConfig.getRetryConfigurations().get(0);


### PR DESCRIPTION
# resilience4j dropwizard bundle PR

Relocate classes and rename artifact groupId

### Changed
* Renamed artifact groupId from `com.expediagroup.dropwizard.bundle` to `com.expediagroup`
* Relocated classes from `com.homeaway.dropwizard.bundle.resilience4j` to `com.expediagroup.dropwizard.resilience4j`


# PR Checklist Forms

- [x] CHANGELOG.md updated
- [ ] Unit test(s) added
- [x] Reviewer assigned
- [ ] PR assigned (presumably to submitter)
- [x] Labels added (enhancement, bug, documentation)
