### PR TITLE
Bump to latest resilience4j version (1.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [?.?.?] - 2020-03-20
+### Changed
+- Updated to R4j 1.3.1. This is a minor version bump that has several changes that will be user-visible. See R4j documentation for details.
+
 ## [2.0.0] - 2019-01-06
 ### Changed
 - Renamed artifact groupId from `com.expediagroup.dropwizard.bundle` to `com.expediagroup`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## [?.?.?] - 2020-03-20
+## [Unreleased]
 ### Changed
 - Updated to R4j 1.3.1. This is a minor version bump that has several changes that will be user-visible. See R4j documentation for details.
 

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <hk2-api.version>2.5.0-b32</hk2-api.version>
         <junit.version>4.12</junit.version>
         <rs-api.version>2.0.1</rs-api.version>
-        <resilience4j.version>1.1.0</resilience4j.version>
+        <resilience4j.version>1.3.1</resilience4j.version>
         <slf4j.version>1.7.25</slf4j.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <vavr.version>0.10.0</vavr.version>


### PR DESCRIPTION
# resilience4j dropwizard bundle PR

Updates dependency to latest resilience4j version, 1.3.1

# PR Checklist Forms

- [x] CHANGELOG.md updated
- [ ] Unit test(s) added
- [ ] Reviewer assigned
- [ ] PR assigned (presumably to submitter)
- [ ] Labels added (enhancement, bug, documentation)
