### PR TITLE
Bundle dependency updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## [Unreleased]
+## [2.0.1] - 2020-03-20
 ### Changed
 - Updated to R4j 1.3.1. This is a minor version bump that has several changes that will be user-visible. See R4j documentation for details.
 
-## [2.0.0] - 2019-01-06
+| Package | Update | Change |
+|---|---|---|
+| org.apache.maven.plugins:maven-compiler-plugin | patch | `3.8.0` -> `3.8.1` |
+| org.apache.maven.plugins:maven-javadoc-plugin | minor | `3.1.1` -> `3.2.0` |
+| org.apache.maven.plugins:maven-source-plugin | minor | `3.0.1` -> `3.2.1` |
+| org.apache.maven.plugins:maven-surefire-plugin | patch | `2.22.1` -> `2.22.2` |
+| org.glassfish.hk2:hk2-api | minor | `2.5.0-b32` -> `2.6.1` |
+| io.vavr:vavr | patch | `0.10.0` -> `0.10.2` |
+| javax.ws.rs:javax.ws.rs-api | minor | `2.0.1` -> `2.1.1` |
+| junit:junit | minor | `4.12` -> `4.13` |
+| io.dropwizard:dropwizard-bom | patch | `1.3.8` -> `1.3.20` |
+
+## [2.0.0] - 2020-01-06
 ### Changed
 - Renamed artifact groupId from `com.expediagroup.dropwizard.bundle` to `com.expediagroup`
 - Relocated classes from `com.homeaway.dropwizard.bundle.resilience4j` to `com.expediagroup.dropwizard.resilience4j`

--- a/pom.xml
+++ b/pom.xml
@@ -56,9 +56,9 @@
         <coverage.branch>0.80</coverage.branch>
 
         <!-- Plugins -->
-        <source.pluginVersion>3.0.1</source.pluginVersion>
-        <surefire.pluginVersion>2.22.1</surefire.pluginVersion>
-        <compiler.pluginVersion>3.8.0</compiler.pluginVersion>
+        <source.pluginVersion>3.2.1</source.pluginVersion>
+        <surefire.pluginVersion>2.22.2</surefire.pluginVersion>
+        <compiler.pluginVersion>3.8.1</compiler.pluginVersion>
         <release.pluginVersion>2.5.3</release.pluginVersion>
         <preparationGoals>clean install</preparationGoals>
 
@@ -67,13 +67,13 @@
 
         <coverage.jacoco.pluginVersion>0.8.5</coverage.jacoco.pluginVersion>
         <dropwizard.version>1.3.20</dropwizard.version>
-        <hk2-api.version>2.5.0-b32</hk2-api.version>
-        <junit.version>4.12</junit.version>
-        <rs-api.version>2.0.1</rs-api.version>
+        <hk2-api.version>2.6.1</hk2-api.version>
+        <junit.version>4.13</junit.version>
+        <rs-api.version>2.1.1</rs-api.version>
         <resilience4j.version>1.3.1</resilience4j.version>
         <slf4j.version>1.7.25</slf4j.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
-        <vavr.version>0.10.0</vavr.version>
+        <vavr.version>0.10.2</vavr.version>
 
     </properties>
 
@@ -200,7 +200,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
# resilience4j dropwizard bundle PR

Dependency updates

| Package | Update | Change |
|---|---|---|
| org.apache.maven.plugins:maven-compiler-plugin | patch | `3.8.0` -> `3.8.1` |
| org.apache.maven.plugins:maven-javadoc-plugin | minor | `3.1.1` -> `3.2.0` |
| org.apache.maven.plugins:maven-source-plugin | minor | `3.0.1` -> `3.2.1` |
| org.apache.maven.plugins:maven-surefire-plugin | patch | `2.22.1` -> `2.22.2` |
| org.glassfish.hk2:hk2-api | minor | `2.5.0-b32` -> `2.6.1` |
| io.vavr:vavr | patch | `0.10.0` -> `0.10.2` |
| javax.ws.rs:javax.ws.rs-api | minor | `2.0.1` -> `2.1.1` |
| junit:junit | minor | `4.12` -> `4.13` |
| io.dropwizard:dropwizard-bom | patch | `1.3.8` -> `1.3.20` |

### Changed
* Dependency updates

# PR Checklist Forms

- [x] CHANGELOG.md updated
- [ ] Unit test(s) added
- [ ] Reviewer assigned
- [ ] PR assigned (presumably to submitter)
- [ ] Labels added (enhancement, bug, documentation)
