### PR TITLE
Workaround API Binary Compatibility breakage in r4j 1.2.0 release -- Update IntervalFunction in signatures to the new/non-deprecated one in r4j core

### DIFF
--- a/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/retry/ConstantIntervalFunctionFactory.java
+++ b/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/retry/ConstantIntervalFunctionFactory.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
 import io.dropwizard.util.Duration;
-import io.github.resilience4j.retry.IntervalFunction;
+import io.github.resilience4j.core.IntervalFunction;
 
 @JsonTypeName("constant")
 public class ConstantIntervalFunctionFactory implements IntervalFunctionFactory {

--- a/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/retry/ExponentialBackoffFunctionFactory.java
+++ b/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/retry/ExponentialBackoffFunctionFactory.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
 import io.dropwizard.util.Duration;
-import io.github.resilience4j.retry.IntervalFunction;
+import io.github.resilience4j.core.IntervalFunction;
 
 @JsonTypeName("exponentialBackoff")
 public class ExponentialBackoffFunctionFactory implements IntervalFunctionFactory {

--- a/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/retry/ExponentialRandomBackoffFunctionFactory.java
+++ b/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/retry/ExponentialRandomBackoffFunctionFactory.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
 import io.dropwizard.util.Duration;
-import io.github.resilience4j.retry.IntervalFunction;
+import io.github.resilience4j.core.IntervalFunction;
 
 @JsonTypeName("exponentialRandomBackoff")
 public class ExponentialRandomBackoffFunctionFactory implements IntervalFunctionFactory {

--- a/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/retry/IntervalFunctionFactory.java
+++ b/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/retry/IntervalFunctionFactory.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import io.dropwizard.jackson.Discoverable;
-import io.github.resilience4j.retry.IntervalFunction;
+import io.github.resilience4j.core.IntervalFunction;
 
 /**
  * A service provider interface for creating Resilience4j {@link IntervalFunction interval functions}.

--- a/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/retry/RandomizedIntervalFunctionFactory.java
+++ b/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/retry/RandomizedIntervalFunctionFactory.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
 import io.dropwizard.util.Duration;
-import io.github.resilience4j.retry.IntervalFunction;
+import io.github.resilience4j.core.IntervalFunction;
 
 @JsonTypeName("randomized")
 public class RandomizedIntervalFunctionFactory implements IntervalFunctionFactory {


### PR DESCRIPTION
# resilience4j dropwizard bundle PR

In r4j release 1.2.0, in Issue #671 in adding IntervalFunction use for circuit breakers, the author copied the IntervalFunction from the retry package to core, and updated the original's super interface to be the new copy.  This will work fine to provide compile time backwards compatibility, but not runtime backwards compatibility... any code that uses this interface that has already been compiled with it at its old pre 1.2.0 signature will get a method not found exception when trying to call methods that were using this interface.  For example:

```
java.lang.NoSuchMethodError: io.github.resilience4j.retry.RetryConfig$Builder.intervalFunction(Lio/github/resilience4j/retry/IntervalFunction;)Lio/github/resilience4j/retry/RetryConfig$Builder;
	at com.expediagroup.dropwizard.resilience4j.configuration.retry.RetryConfiguration.toResilience4jConfigBuilder(RetryConfiguration.java:48)
	at com.expediagroup.dropwizard.resilience4j.Resilience4jBundle.run(Resilience4jBundle.java:122)
	at io.dropwizard.setup.Bootstrap.run(Bootstrap.java:200)
```

This is the change that caused this issue:
https://github.com/resilience4j/resilience4j/pull/665/files#diff-e9f845d17540ab6271d786b1a51f1274L12

With this fix, any client upgrading dropwizard-resilience4j-bundle will need to be using 1.2.0 or higher.

### Changed
* Changed to use the new IntervalFunction from r4j core instead of retry to work around binary incompatible change introduced in resilience4j 1.2.0

# PR Checklist Forms

- [ ] CHANGELOG.md updated
- [ ] Unit test(s) added
- [ ] Reviewer assigned
- [ ] PR assigned (presumably to submitter)
- [ ] Labels added (enhancement, bug, documentation)
