### PR TITLE
Upgrade to Dropwizard 2.x and Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: java
 dist: trusty
 
 jdk:
-  - openjdk8
+  - openjdk11
 
 # 'true' means do NOT do `mvn install`
 # See https://docs.travis-ci.com/user/job-lifecycle/#skipping-the-installation-phase

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [3.0.0] - TBD
+### Changed
+- Upgrade to Dropwizard 2.x.
+- Switched to Java 11
+- Switched from JUnit 4 to JUnit 5
+- Renamed artifact groupId from `com.expediagroup` to `com.expediagroup.dropwizard`
+
 ## [2.0.1] - 2020-03-20
 ### Changed
 - Updated to R4j 1.3.1. This is a minor version bump that has several changes that will be user-visible. See R4j documentation for details.

--- a/pom.xml
+++ b/pom.xml
@@ -3,9 +3,9 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.expediagroup</groupId>
+    <groupId>com.expediagroup.dropwizard</groupId>
     <artifactId>dropwizard-resilience4j-bundle</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>dropwizard-resilience4j-bundle</name>
@@ -44,8 +44,8 @@
 
     <properties>
         <!--Java-->
-        <java.source.version>1.8</java.source.version>
-        <java.target.version>1.8</java.target.version>
+        <java.source.version>11</java.source.version>
+        <java.target.version>11</java.target.version>
 
         <!--Encoding-->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -56,23 +56,27 @@
         <coverage.branch>0.80</coverage.branch>
 
         <!-- Plugins -->
+        <compiler.pluginVersion>3.8.1</compiler.pluginVersion>
+        <coverage.jacoco.pluginVersion>0.8.5</coverage.jacoco.pluginVersion>
+        <enforcer.pluginVersion>3.0.0-M3</enforcer.pluginVersion>
+        <preparationGoals>clean install</preparationGoals>
+        <release.pluginVersion>2.5.3</release.pluginVersion>
         <source.pluginVersion>3.2.1</source.pluginVersion>
         <surefire.pluginVersion>2.22.2</surefire.pluginVersion>
-        <compiler.pluginVersion>3.8.1</compiler.pluginVersion>
-        <release.pluginVersion>2.5.3</release.pluginVersion>
-        <preparationGoals>clean install</preparationGoals>
 
         <!-- OSSRH -->
         <nexusStaging.pluginVersion>1.6.8</nexusStaging.pluginVersion>
 
-        <coverage.jacoco.pluginVersion>0.8.5</coverage.jacoco.pluginVersion>
-        <dropwizard.version>1.3.20</dropwizard.version>
+        <assertj.version>3.15.0</assertj.version>
+        <dropwizard.version>2.0.12</dropwizard.version>
         <hk2-api.version>2.6.1</hk2-api.version>
-        <junit.version>4.13</junit.version>
+        <jackson.version>2.10.3</jackson.version>
+        <junit5.version>5.6.2</junit5.version>
+        <metrics4.version>4.1.2</metrics4.version>
         <rs-api.version>2.1.1</rs-api.version>
         <resilience4j.version>1.4.0</resilience4j.version>
         <slf4j.version>1.7.25</slf4j.version>
-        <validation-api.version>1.1.0.Final</validation-api.version>
+        <validation-api.version>2.0.2</validation-api.version>
         <vavr.version>0.10.2</vavr.version>
 
     </properties>
@@ -80,11 +84,75 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-bom</artifactId>
                 <version>${dropwizard.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-bom</artifactId>
+                <version>${metrics4.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>io.github.resilience4j</groupId>
+                <artifactId>resilience4j-circuitbreaker</artifactId>
+                <version>${resilience4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.resilience4j</groupId>
+                <artifactId>resilience4j-metrics</artifactId>
+                <version>${resilience4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.resilience4j</groupId>
+                <artifactId>resilience4j-retry</artifactId>
+                <version>${resilience4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.vavr</groupId>
+                <artifactId>vavr</artifactId>
+                <version>${vavr.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.validation</groupId>
+                <artifactId>jakarta.validation-api</artifactId>
+                <version>${validation-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.hk2</groupId>
+                <artifactId>hk2-api</artifactId>
+                <version>${hk2-api.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${assertj.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>${junit5.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>${junit5.version}</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -93,10 +161,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
@@ -121,36 +185,26 @@
         <dependency>
             <groupId>io.github.resilience4j</groupId>
             <artifactId>resilience4j-circuitbreaker</artifactId>
-            <version>${resilience4j.version}</version>
         </dependency>
         <dependency>
             <groupId>io.github.resilience4j</groupId>
             <artifactId>resilience4j-metrics</artifactId>
-            <version>${resilience4j.version}</version>
         </dependency>
         <dependency>
             <groupId>io.github.resilience4j</groupId>
             <artifactId>resilience4j-retry</artifactId>
-            <version>${resilience4j.version}</version>
         </dependency>
         <dependency>
             <groupId>io.vavr</groupId>
             <artifactId>vavr</artifactId>
-            <version>${vavr.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
-            <version>${validation-api.version}</version>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.hk2</groupId>
             <artifactId>hk2-api</artifactId>
-            <version>${hk2-api.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-validator</artifactId>
         </dependency>
 
         <!-- Test scoped dependencies -->
@@ -158,22 +212,21 @@
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-testing</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-            <version>${rs-api.version}</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -207,6 +260,39 @@
                         <goals>
                             <goal>jar</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>${enforcer.pluginVersion}</version>
+                <executions>
+                    <execution>
+                        <id>enforce-jakarta-apis</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <bannedDependencies>
+                                    <excludes>
+                                        <!-- Replaced with jakarta.activation:jakarta.activation-api -->
+                                        <exclude>javax.activation:javax.activation-api</exclude>
+                                        <!-- Replaced with jakarta.annotation:jakarta.annotation-api -->
+                                        <exclude>javax.annotation:javax.annotation-api</exclude>
+                                        <!-- Replaced with jakarta.inject:jakarta.inject-api or org.glassfish.hk2.external:jakarta.inject -->
+                                        <exclude>javax.inject:javax.inject</exclude>
+                                        <!-- Replaced with jakarta.servlet:jakarta.servlet-api -->
+                                        <exclude>javax.servlet:javax.servlet-api</exclude>
+                                        <!-- Replaced with jakarta.validation:jakarta.validation-api -->
+                                        <exclude>javax.validation:validation-api</exclude>
+                                        <!-- Replaced with jakarta.xml.bind:jakarta.xml.bind-api -->
+                                        <exclude>javax.xml.bind:jaxb-api</exclude>
+                                    </excludes>
+                                </bannedDependencies>
+                            </rules>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/retry/RetryConfiguration.java
+++ b/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/retry/RetryConfiguration.java
@@ -1,8 +1,7 @@
 package com.expediagroup.dropwizard.resilience4j.configuration.retry;
 
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
-
-import org.hibernate.validator.constraints.NotEmpty;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/src/test/java/com/expediagroup/dropwizard/resilience4j/circuitbreaker/CircuitBreakerConfigTest.java
+++ b/src/test/java/com/expediagroup/dropwizard/resilience4j/circuitbreaker/CircuitBreakerConfigTest.java
@@ -3,8 +3,9 @@ package com.expediagroup.dropwizard.resilience4j.circuitbreaker;
 import java.util.List;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import com.expediagroup.dropwizard.resilience4j.configuration.CircuitBreakerConfiguration;
 import com.expediagroup.dropwizard.resilience4j.configuration.Resilience4jConfiguration;
@@ -12,21 +13,24 @@ import com.expediagroup.dropwizard.resilience4j.ResourceTestUtil;
 import com.expediagroup.dropwizard.resilience4j.TestApplication;
 import com.expediagroup.dropwizard.resilience4j.TestConfiguration;
 
-import io.dropwizard.testing.junit.DropwizardAppRule;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.dropwizard.util.Duration;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CircuitBreakerConfigTest {
+@ExtendWith(DropwizardExtensionsSupport.class)
+@DisplayName("CircuitBreakerConfig")
+class CircuitBreakerConfigTest {
 
-    //Checking to make sure the app can actually start
-    @Rule
-    public DropwizardAppRule<TestConfiguration> app =
-        new DropwizardAppRule<>(TestApplication.class, ResourceTestUtil.resourceAbsolutePath("/circuitbreaker/config-cb.yaml"));
+    // Checking to make sure the app can actually start
+    public DropwizardAppExtension<TestConfiguration> app =
+        new DropwizardAppExtension<>(TestApplication.class, ResourceTestUtil.resourceAbsolutePath("/circuitbreaker/config-cb.yaml"));
 
     @Test
-    public void configWithJustCircuitBreaker_runs() throws Exception {
+    @DisplayName("circuit breaker configuration parses successfully")
+    void configWithJustCircuitBreaker_runs() {
         Resilience4jConfiguration r4jConfig = app.getConfiguration().getResilience4j();
         assertThat(r4jConfig).isNotNull();
         assertThat(r4jConfig.getCircuitBreakers()).isNotNull();

--- a/src/test/java/com/expediagroup/dropwizard/resilience4j/retry/RetryConfigTest.java
+++ b/src/test/java/com/expediagroup/dropwizard/resilience4j/retry/RetryConfigTest.java
@@ -1,8 +1,9 @@
 package com.expediagroup.dropwizard.resilience4j.retry;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import com.expediagroup.dropwizard.resilience4j.configuration.Resilience4jConfiguration;
 import com.expediagroup.dropwizard.resilience4j.configuration.retry.ConstantIntervalFunctionFactory;
@@ -14,18 +15,21 @@ import com.expediagroup.dropwizard.resilience4j.configuration.retry.ExponentialB
 import com.expediagroup.dropwizard.resilience4j.configuration.retry.ExponentialRandomBackoffFunctionFactory;
 import com.expediagroup.dropwizard.resilience4j.configuration.retry.RandomizedIntervalFunctionFactory;
 
-import io.dropwizard.testing.junit.DropwizardAppRule;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class RetryConfigTest {
+@ExtendWith(DropwizardExtensionsSupport.class)
+@DisplayName("RetryConfig")
+class RetryConfigTest {
 
-    @Rule
-    public DropwizardAppRule<TestConfiguration> app =
-        new DropwizardAppRule<>(TestApplication.class, ResourceTestUtil.resourceAbsolutePath("/retry/config-retry.yaml"));
+    public DropwizardAppExtension<TestConfiguration> app =
+        new DropwizardAppExtension<>(TestApplication.class, ResourceTestUtil.resourceAbsolutePath("/retry/config-retry.yaml"));
 
     @Test
-    public void configWithJustRetry_runs() throws Exception {
+    @DisplayName("retry configuration parses successfully")
+    void configWithJustRetry_runs() {
         Resilience4jConfiguration r4jConfig = app.getConfiguration().getResilience4j();
 
         //Check that retry was configured correctly


### PR DESCRIPTION
# resilience4j dropwizard bundle PR

Upgrade to Dropwizard 2.x and Java 11

### Changed
* Upgrade to Dropwizard 2.x
* Switched to Java 11
* Switched from JUnit 4 to JUnit 5
* Renamed artifact groupId from `com.expediagroup` to `com.expediagroup.dropwizard`


# PR Checklist Forms

- [ ] CHANGELOG.md updated
- [ ] Unit test(s) added
- [ ] Reviewer assigned
- [ ] PR assigned (presumably to submitter)
- [ ] Labels added (enhancement, bug, documentation)
