### PR TITLE
Update to resilience4j 1.5.0 and replace deprecated IntervalFunction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Switched to Java 11
 - Switched from JUnit 4 to JUnit 5
 - Renamed artifact groupId from `com.expediagroup` to `com.expediagroup.dropwizard`
+- Update to R4j `1.5.0`
+- Replace the use of deprecated `io.github.resilience4j.retry.IntervalFunction` with `io.github.resilience4j.core.IntervalFunction`
 
 ## [2.0.1] - 2020-03-20
 ### Changed

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <junit5.version>5.6.2</junit5.version>
         <metrics4.version>4.1.2</metrics4.version>
         <rs-api.version>2.1.1</rs-api.version>
-        <resilience4j.version>1.4.0</resilience4j.version>
+        <resilience4j.version>1.5.0</resilience4j.version>
         <slf4j.version>1.7.25</slf4j.version>
         <validation-api.version>2.0.2</validation-api.version>
         <vavr.version>0.10.2</vavr.version>

--- a/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/retry/ConstantIntervalFunctionFactory.java
+++ b/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/retry/ConstantIntervalFunctionFactory.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
 import io.dropwizard.util.Duration;
-import io.github.resilience4j.retry.IntervalFunction;
+import io.github.resilience4j.core.IntervalFunction;
 
 @JsonTypeName("constant")
 public class ConstantIntervalFunctionFactory implements IntervalFunctionFactory {

--- a/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/retry/ExponentialBackoffFunctionFactory.java
+++ b/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/retry/ExponentialBackoffFunctionFactory.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
 import io.dropwizard.util.Duration;
-import io.github.resilience4j.retry.IntervalFunction;
+import io.github.resilience4j.core.IntervalFunction;
 
 @JsonTypeName("exponentialBackoff")
 public class ExponentialBackoffFunctionFactory implements IntervalFunctionFactory {

--- a/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/retry/ExponentialRandomBackoffFunctionFactory.java
+++ b/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/retry/ExponentialRandomBackoffFunctionFactory.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
 import io.dropwizard.util.Duration;
-import io.github.resilience4j.retry.IntervalFunction;
+import io.github.resilience4j.core.IntervalFunction;
 
 @JsonTypeName("exponentialRandomBackoff")
 public class ExponentialRandomBackoffFunctionFactory implements IntervalFunctionFactory {

--- a/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/retry/IntervalFunctionFactory.java
+++ b/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/retry/IntervalFunctionFactory.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import io.dropwizard.jackson.Discoverable;
-import io.github.resilience4j.retry.IntervalFunction;
+import io.github.resilience4j.core.IntervalFunction;
 
 /**
  * A service provider interface for creating Resilience4j {@link IntervalFunction interval functions}.

--- a/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/retry/RandomizedIntervalFunctionFactory.java
+++ b/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/retry/RandomizedIntervalFunctionFactory.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
 import io.dropwizard.util.Duration;
-import io.github.resilience4j.retry.IntervalFunction;
+import io.github.resilience4j.core.IntervalFunction;
 
 @JsonTypeName("randomized")
 public class RandomizedIntervalFunctionFactory implements IntervalFunctionFactory {


### PR DESCRIPTION
# resilience4j dropwizard bundle PR

Update to resilience4j `1.5.0` and replace deprecated `io.github.resilience4j.retry.IntervalFunction`

### Changed
* Update to R4j `1.5.0`
* Replace the use of deprecated `io.github.resilience4j.retry.IntervalFunction` with `io.github.resilience4j.core.IntervalFunction`


# PR Checklist Forms

- [x] CHANGELOG.md updated
- [ ] Unit test(s) added
- [ ] Reviewer assigned
- [ ] PR assigned (presumably to submitter)
- [ ] Labels added (enhancement, bug, documentation)
