### PR TITLE
fix: Announce end of support for this bundle, mark classes deprecated for visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
-dropwizard-resilience4j-bundle
+dropwizard-resilience4j-bundle (DEPRECATED)
 ==============================
 
 [![Release](https://github.com/ExpediaGroup/dropwizard-resilience4j-bundle/actions/workflows/release.yml/badge.svg)](https://github.com/ExpediaGroup/dropwizard-resilience4j-bundle/actions/workflows/release.yml)
+
+**DEPRECATED: We no longer maintain dropwizard-resilience4j-bundle. If you have questions or concerns, please open an
+issue or fork this repository.**
 
 Lightweight integration of Resilience4J into Dropwizard configuration and metrics. Does not provide any other services - actually _using_
 all the Resilience4j stuff is up to you. The [R4J documentation](https://resilience4j.readme.io/docs) is pretty good.

--- a/src/main/java/com/expediagroup/dropwizard/resilience4j/Resilience4jBundle.java
+++ b/src/main/java/com/expediagroup/dropwizard/resilience4j/Resilience4jBundle.java
@@ -47,6 +47,10 @@ import io.github.resilience4j.timelimiter.TimeLimiterConfig;
 import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
 import io.github.resilience4j.timelimiter.internal.InMemoryTimeLimiterRegistry;
 
+/**
+ * @deprecated See <a href="https://github.com/ExpediaGroup/dropwizard-resilience4j-bundle/blob/master/README.md">README.md</a>
+ */
+@Deprecated
 public class Resilience4jBundle<T> implements ConfiguredBundle<T> {
 
     private final Function<T, Resilience4jConfiguration> resiliencyConfiguratorFunction;
@@ -57,9 +61,11 @@ public class Resilience4jBundle<T> implements ConfiguredBundle<T> {
 
     /**
      * Create a new bundle
+     * @deprecated See <a href="https://github.com/ExpediaGroup/dropwizard-resilience4j-bundle/blob/master/README.md">README.md</a>
      *
      * @param resilienceConfiguratorFunction Function to extract the Resilience4j configuration from the dropwizard configuration
      */
+    @Deprecated
     public Resilience4jBundle(@NonNull Function<T, Resilience4jConfiguration> resilienceConfiguratorFunction) {
         this(resilienceConfiguratorFunction,
              noOpConfigurator(),
@@ -68,11 +74,13 @@ public class Resilience4jBundle<T> implements ConfiguredBundle<T> {
 
     /**
      * Create a new bundle, with a function for modifying CircuitBreaker configurations
+     * @deprecated See <a href="https://github.com/ExpediaGroup/dropwizard-resilience4j-bundle/blob/master/README.md">README.md</a>
      *
      * @param resilienceConfiguratorFunction Function to extract the Resilience4j configuration from the dropwizard configuration
      * @param circuitBreakerConfigurator A function that will be passed the name and builder for each circuit breaker before it is created
      * @param retryConfigurator A function that will be passed the name and builder for each retryer
      */
+    @Deprecated
     public Resilience4jBundle(@NonNull Function<T, Resilience4jConfiguration> resilienceConfiguratorFunction,
                               @NonNull BiConsumer<String, CircuitBreakerConfig.Builder> circuitBreakerConfigurator,
                               @NonNull BiConsumer<String, RetryConfig.Builder> retryConfigurator) {

--- a/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/CircuitBreakerConfiguration.java
+++ b/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/CircuitBreakerConfiguration.java
@@ -23,7 +23,9 @@ import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 
 /**
  * A configuration for CircuitBreaker.
+ * @deprecated See <a href="https://github.com/ExpediaGroup/dropwizard-resilience4j-bundle/blob/master/README.md">README.md</a>
  */
+@Deprecated
 public class CircuitBreakerConfiguration {
 
     /**

--- a/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/Resilience4jConfiguration.java
+++ b/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/Resilience4jConfiguration.java
@@ -29,7 +29,9 @@ import io.github.resilience4j.timelimiter.TimeLimiterRegistry;
 
 /**
  * Resilience4j configuration
+ * @deprecated See <a href="https://github.com/ExpediaGroup/dropwizard-resilience4j-bundle/blob/master/README.md">README.md</a>
  */
+@Deprecated
 public class Resilience4jConfiguration {
 
     /**

--- a/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/TimeLimiterConfiguration.java
+++ b/src/main/java/com/expediagroup/dropwizard/resilience4j/configuration/TimeLimiterConfiguration.java
@@ -23,7 +23,9 @@ import io.github.resilience4j.timelimiter.TimeLimiterConfig;
 
 /**
  * A configuration for TimeLimiter.
+ * @deprecated See <a href="https://github.com/ExpediaGroup/dropwizard-resilience4j-bundle/blob/master/README.md">README.md</a>
  */
+@Deprecated
 public class TimeLimiterConfiguration {
 
     /**


### PR DESCRIPTION
# resilience4j dropwizard bundle PR

The Expedia Group team behind the dropwizard-resilience4j-bundle will no longer be supporting it.

The public-facing classes are marked as deprecated so as to alert developers that use the package of its new state.

### Added
* Message in README about the bundle being marked deprecated

### Changed
* marked the Resilience4jBundle class as `@Deprecated`
* marked the CircuitBreakerConfiguration class as `@Deprecated`
* marked the Resilience4jConfiguration class as `@Deprecated`
* marked the TimeLimiterConfiguration class as `@Deprecated`

# PR Checklist Forms

- [ ] CHANGELOG.md updated
- [ ] Unit test(s) added
- [ ] Reviewer assigned
- [ ] PR assigned (presumably to submitter)
- [ ] Labels added (enhancement, bug, documentation)
